### PR TITLE
Between 1 and 20 digits per image

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -113,7 +113,7 @@ def generate_dataset(dirpath: pathlib.Path,
         labels = []
         bboxes = []
         num_images = np.random.randint(0, max_digits_per_image)
-        for _ in range(num_images):
+        for _ in range(num_images+1):
             while True:
                 width = np.random.randint(min_digit_size, max_digit_size)
                 x0 = np.random.randint(0, imsize-width)


### PR DESCRIPTION
According to the README.md, the generated dataset has between 1-20 digits per image, but the code was generating some images with 0 digits, i.e just a black image.

Issue:

```python
num_images = np.random.randint(0, max_digits_per_image) # chooses a random integer between 0 and max_digits_per_image-1
for _ in range(num_images): # wont run if the num_images  == 0
```

Hence, updated the loop initialization step.